### PR TITLE
chore: export node version number to vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Update the version
 
-Modify the verion number in `vendor.ts`, and run:
+Modify the verion number in `node_version.ts`, and run:
 
 ```
 deno task vendor

--- a/node_version.ts
+++ b/node_version.ts
@@ -1,0 +1,3 @@
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
+
+export const version = "20.11.1";

--- a/vendor.ts
+++ b/vendor.ts
@@ -1,11 +1,12 @@
-// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
 
 /** This scripts vendors the test/ dir of nodejs repository to local ./test dir */
 
 import $ from "https://deno.land/x/dax@0.31.1/mod.ts";
+import { version } from "./node_version.ts";
 
 // The version to vendor
-const tag = "v20.11.1";
+const tag = "v" + version;
 
 await $`rm -rf node`;
 await $`git clone --depth 1 --sparse --branch ${tag} --single-branch https://github.com/nodejs/node.git`;


### PR DESCRIPTION
This PR adds `node_version.ts` which exports the vendored version number, which can be re-used in CLI repo.