### PR TITLE
chore: add package.json with type=commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
By adding this file, the files under `test/` can be run by deno with the command:

```
deno -A --unstable-bare-node-builtins test/parallel/test-assert-async.js
```

(currently this errors with `TypeError: getCallSites is not a function` though)