### PR TITLE
fix: avoid changing line endings to CRLF on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/fixtures/* -text


### PR DESCRIPTION
Git uses the OS default line endings unless specified, that is CRLF on Windows. This has caused our test fixtures to have incorrect line endings on Windows and makes some of the tests failed.

<img width="1576" height="400" alt="Screenshot 2025-08-21 215405" src="https://github.com/user-attachments/assets/39d50011-7273-4086-bea5-27d551adc9dc" />

The changes are based on https://github.com/nodejs/node/blob/main/.gitattributes